### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -125,7 +125,7 @@ int LoadPauseKeyFromSettingsFile(_In_ wchar_t* Filename)
 		}
 
 		size_t Length = strlen(KeyLine);
-		if (Length > 30)
+		if (Length > 20)
 		{
 			goto Default;
 		}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

If you opens file "settings.txt" and enters long string into KEY value, larger then 20 symbols, and run application, it will be crashed. I have limited the maximum KeyLine length to 20 symbols.

[V557](https://www.viva64.com/en/w/v557/) Array overrun is possible. The value of 'Counter - 4' index could reach 26. main.cpp 146
