### PR TITLE
Resume previous process even if hotkey is not on the same previous processid window

### DIFF
--- a/Main.c
+++ b/Main.c
@@ -417,9 +417,17 @@ int CALLBACK WinMain(_In_ HINSTANCE Instance, _In_opt_ HINSTANCE PreviousInstanc
 
 					if (PreviouslySuspendedProcessIsStillRunning)
 					{
+						NtResumeProcess(OpenProcess(PROCESS_ALL_ACCESS, FALSE, PreviouslySuspendedProcessID));
+
 						wchar_t MessageBoxBuffer[1024] = { 0 };
 
-						_snwprintf_s(MessageBoxBuffer, sizeof(MessageBoxBuffer), _TRUNCATE, L"You must first unpause %s (PID %d) before pausing another program.", PreviouslySuspendedProcessText, PreviouslySuspendedProcessID);
+						_snwprintf_s(MessageBoxBuffer, sizeof(MessageBoxBuffer), _TRUNCATE, L"Resumed %s (PID %d)", PreviouslySuspendedProcessText, PreviouslySuspendedProcessID);
+
+						PreviouslySuspendedProcessID = 0;
+
+						PreviouslySuspendedWnd = 0;
+
+						memset(PreviouslySuspendedProcessText, 0, sizeof(PreviouslySuspendedProcessText));
 
 						MessageBox(ForegroundWindow, MessageBoxBuffer, L"Universal Pause Button", MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
 					}


### PR DESCRIPTION
If a program is paused, pressing Hotkey on another window will resume previous process.
Very useful if I want to pause a game for a long period of time without Windows freaking out